### PR TITLE
better practice in accessing elements in cypress

### DIFF
--- a/gatsby/cypress/e2e/all.cy.js
+++ b/gatsby/cypress/e2e/all.cy.js
@@ -1,0 +1,37 @@
+import { mobile, desktop, waitTime, errorThreshold } from '../support/utils.js'
+
+function runTests(device, orientation) {
+  describe('all screens tests: ' + device + ' (' + orientation + ')', () => {
+    beforeEach(() => {
+      cy.viewport(device, orientation)
+      cy.visit('/')
+      cy.wait(waitTime)
+    })
+
+    it('has 6 sections', () => {
+      const sections = cy.get('section')
+      sections.should('have.length', 6)
+    })
+
+    it('insight img visibility', () => {
+      const img_top = cy.get('[data-cy="insight-img-a"]')
+      const img_bottom = cy.get('[data-cy="insight-img-b"]')
+
+      // without this sometimes they don't show up in the screenshot
+      img_top.should('be.visible')
+      img_bottom.should('be.visible')
+    })
+  })
+}
+
+mobile.devices.forEach((device) => {
+  mobile.orientationList.forEach((orientation) => {
+    runTests(device, orientation)
+  })
+})
+
+desktop.devices.forEach((device) => {
+  desktop.orientationList.forEach((orientation) => {
+    runTests(device, orientation)
+  })
+})

--- a/gatsby/cypress/e2e/desktop.cy.js
+++ b/gatsby/cypress/e2e/desktop.cy.js
@@ -3,32 +3,13 @@ import { desktop, waitTime, errorThreshold } from '../support/utils.js'
 desktop.devices.forEach((device) => {
   desktop.orientationList.forEach((orientation) => {
     describe('desktop tests: ' + device + ' (' + orientation + ')', () => {
-      before(() => {
-        cy.viewport(device, orientation)
-      })
-
       beforeEach(() => {
+        cy.viewport(device, orientation)
         cy.visit('/')
+        cy.wait(waitTime)
       })
 
       it('page', () => {
-        const sections = cy.get('section')
-        sections.should('have.length', 6)
-
-        //// get 2nd section
-        const div = sections.eq(1).get('div')
-        const img_left = div.eq(0).get('img').eq(0)
-        const img_right = div.eq(0).get('img').eq(1)
-
-        //// without this sometimes they don't show up in the screenshot
-        img_left.should('be.visible')
-        img_right.should('be.visible')
-        
-        // wait for rendering to finish
-        cy.wait(waitTime, {
-          errorThreshold: errorThreshold
-        })
-
         const fname = 'page_desktop_' + device + '_' + orientation
         cy.compareSnapshot(fname)
       })

--- a/gatsby/cypress/e2e/mobile.cy.js
+++ b/gatsby/cypress/e2e/mobile.cy.js
@@ -9,27 +9,6 @@ mobile.devices.forEach((device) => {
         cy.wait(waitTime)
       })
 
-      it('page', () => {
-        const sections = cy.get('section')
-        sections.should('have.length', 6)
-
-        // get 2nd section
-        const div = sections.eq(1).get('div')
-        const img_top = div.eq(0).get('img').eq(0)
-        const img_bottom = div.eq(0).get('img').eq(1)
-
-        // without this sometimes they don't show up in the screenshot
-        img_top.should('be.visible')
-        img_bottom.should('be.visible')
-
-        // wait for rendering to finish
-        cy.wait(waitTime)
-
-        cy.compareSnapshot('page_mobile_' + device + '_' + orientation, {
-          errorThreshold: errorThreshold
-        })
-      })
-
       it('navbar non-expanded', () => {
         const header = cy.get('header')
         const nav = cy.get('header nav')
@@ -40,6 +19,12 @@ mobile.devices.forEach((device) => {
         } else {
           svg.should('be.visible')
         }
+      })
+
+      it('page screenshot', () => {
+        cy.compareSnapshot('page_mobile_' + device + '_' + orientation, {
+          errorThreshold: errorThreshold
+        })
       })
     })
   })

--- a/gatsby/cypress/e2e/mobile.cy.js
+++ b/gatsby/cypress/e2e/mobile.cy.js
@@ -10,10 +10,7 @@ mobile.devices.forEach((device) => {
       })
 
       it('navbar non-expanded', () => {
-        const header = cy.get('header')
-        const nav = cy.get('header nav')
-        nav.should('be.visible')
-        const svg = header.get('svg')
+        const svg = cy.get('[data-cy="chilidog-svg"]')
         if (orientation === 'landscape' && ['iphone-6+', 'iphone-x', 'iphone-xr', 'samsung-note9', 'samsung-s10'].includes(device)) {
           svg.should('not.be.visible')
         } else {

--- a/gatsby/src/components/info.tsx
+++ b/gatsby/src/components/info.tsx
@@ -20,6 +20,7 @@ function HashTags(props: HashTagsProps) {
 interface InsightProps {
   title: string
   src: string
+  dataCy: string
   tags: string[]
 }
 
@@ -33,6 +34,7 @@ export function Insight(props: InsightProps) {
           className={imgClassName}
           src={props.src} 
           alt={props.alt}
+          data-cy={props.dataCy}
         />
         <HashTags tags={props.tags} />
         <p>{props.title}</p>

--- a/gatsby/src/components/navbar.tsx
+++ b/gatsby/src/components/navbar.tsx
@@ -20,7 +20,7 @@ export default function NavBar() {
         // to make jest tests work, sigh...
         // TODO find a better way to do this
         // see https://github.com/syntapy/superformula_clone/issues/31
-        icon={<Chilidogmenu width={32} height={45}/>}
+        icon={<Chilidogmenu width={32} height={45} data-cy="chilidog-svg"/>}
         alt={"Menu"}
         className={chilidog}
       />

--- a/gatsby/src/components/section.tsx
+++ b/gatsby/src/components/section.tsx
@@ -49,6 +49,7 @@ export function HeaderSection(props: HeaderSectionProps) {
 
 interface InsightsSectionProps {
   title: string
+  dataCy: string
   children: JSX.Element
 }
 
@@ -57,7 +58,7 @@ export function InsightsSection(props: InsightsSectionProps) {
   return (
     <React.Fragment>
       <h2>{props.title}</h2>
-      <div className={className}>
+      <div className={className} >
         {props.children}
       </div>
     </React.Fragment>

--- a/gatsby/src/pages/index.tsx
+++ b/gatsby/src/pages/index.tsx
@@ -50,12 +50,14 @@ const IndexPage = () => {
               title="Opportunities: How Superformula team members step up" 
               href="/articles/unexpected-opportunities-how-superformula-team-members-step-up"
               src={img_a}
+              dataCy="insight-img-a"
               tags={["experience", "culture"]}
             />
             <Insight 
               title="Save time! Optimizing rebuilds With Flutter" 
               href="/articles/optimizing-rebuilds-with-flutter"
               src={img_b}
+              dataCy="insight-img-b"
               tags={["flutter", "dart", "tips"]}
             />
           </InsightsSection>


### PR DESCRIPTION
Use `data-cy="<attr-name>"` in elements accessed by Cypress tests for more robustness according to [Cypress Best Practices](https://docs.cypress.io/guides/references/best-practices#Selecting-Elements)

Also refactors tests a bit to separate out tests that apply to all screens vs only mobile or only desktop