### PR TITLE
always produce e2e diff images

### DIFF
--- a/gatsby/cypress.config.ts
+++ b/gatsby/cypress.config.ts
@@ -8,6 +8,7 @@ import fs from 'fs'
 export default defineConfig({
   env: {
     screenshotsFolder: './cypress/snapshots/actual',
+    visualRegressionGenerateDiff: 'always',
     type: 'regression',
     trashAssetsBeforeRuns: true,
     failSilently: false,


### PR DESCRIPTION
Basically because of https://github.com/cypress-visual-regression/cypress-visual-regression/issues/263